### PR TITLE
Change API result status to string due to custom status

### DIFF
--- a/Checkmarx.API.AST.Tests/ScanResultsTests.cs
+++ b/Checkmarx.API.AST.Tests/ScanResultsTests.cs
@@ -119,7 +119,7 @@ namespace Checkmarx.API.AST.Tests
         [TestMethod]
         public void GetLastCommentNoteTest()
         {
- 
+
             var similarityId = "-1661514465";
             Guid projectId = new Guid("1b6f5699-b459-40fa-9e12-b4c84436b5ab");
 
@@ -152,7 +152,7 @@ namespace Checkmarx.API.AST.Tests
             astClient.MarkSASTResult(ProjectId,
                                      "-203301157",
                                      ResultsSeverity.HIGH,
-                                     ResultsState.CONFIRMED,
+                                     ResultsState.CONFIRMED.ToString(),
                                      Guid.Empty,
                                      null);
 
@@ -175,7 +175,7 @@ namespace Checkmarx.API.AST.Tests
                 astClient.MarkSASTResult(ProjectId,
                     vuln.SimilarityID,
                     vuln.Severity,
-                    GetRandomEnumMember<ResultsState>(), lastScan.Id,
+                    GetRandomEnumMember<ResultsState>().ToString(), lastScan.Id,
                     null);
             }
         }

--- a/Checkmarx.API.AST/Models/ResultState.cs
+++ b/Checkmarx.API.AST/Models/ResultState.cs
@@ -1,0 +1,27 @@
+﻿using Checkmarx.API.AST.Models.SCA;
+using Checkmarx.API.AST.Services.KicsResults;
+using Checkmarx.API.AST.Services.SASTResults;
+
+namespace Checkmarx.API.AST.Models
+{
+    public abstract class ResultState
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class SASTResultState : ResultState
+    {
+        public ResultsState? State { get; set; }
+    }
+
+    public class SCAResultState : ResultState
+    {
+        public ScaVulnerabilityStatus State { get; set; }
+    }
+
+    public class KicsResultState : ResultState
+    {
+        public KicsStateEnum State { get; set; }
+    }
+}

--- a/Checkmarx.API.AST/Models/ScanDetails.cs
+++ b/Checkmarx.API.AST/Models/ScanDetails.cs
@@ -398,7 +398,7 @@ namespace Checkmarx.API.AST.Models
 
                 bool isNotInfo = vuln.Severity != ResultsSeverity.INFO;
 
-                if (vuln.State != ResultsState.NOT_EXPLOITABLE)
+                if (vuln.State != ResultsState.NOT_EXPLOITABLE.ToString())
                 {
                     total++;
 
@@ -407,22 +407,22 @@ namespace Checkmarx.API.AST.Models
                         case ResultsSeverity.CRITICAL:
                             critical++;
                             queriesCritical.Add(vuln.QueryID);
-                            if (vuln.State == ResultsState.TO_VERIFY) criticalToVerify++;
+                            if (vuln.State == ResultsState.TO_VERIFY.ToString()) criticalToVerify++;
                             break;
                         case ResultsSeverity.HIGH:
                             high++;
                             queriesHigh.Add(vuln.QueryID);
-                            if (vuln.State == ResultsState.TO_VERIFY) highToVerify++;
+                            if (vuln.State == ResultsState.TO_VERIFY.ToString()) highToVerify++;
                             break;
                         case ResultsSeverity.MEDIUM:
                             medium++;
                             queriesMedium.Add(vuln.QueryID);
-                            if (vuln.State == ResultsState.TO_VERIFY) mediumToVerify++;
+                            if (vuln.State == ResultsState.TO_VERIFY.ToString()) mediumToVerify++;
                             break;
                         case ResultsSeverity.LOW:
                             low++;
                             queriesLow.Add(vuln.QueryID);
-                            if (vuln.State == ResultsState.TO_VERIFY) lowToVerify++;
+                            if (vuln.State == ResultsState.TO_VERIFY.ToString()) lowToVerify++;
                             break;
                         case ResultsSeverity.INFO:
                             info++;
@@ -431,23 +431,16 @@ namespace Checkmarx.API.AST.Models
 
                     if (isNotInfo)
                     {
-                        switch (vuln.State)
+                        if (vuln.State == ResultsState.TO_VERIFY.ToString())
+                            toVerify++;
+                        else if (vuln.State == ResultsState.NOT_EXPLOITABLE.ToString())
+                            notExploitableMarked++;
+                        else if (vuln.State == ResultsState.PROPOSED_NOT_EXPLOITABLE.ToString())
+                            pneMarked++;
+                        else
                         {
-                            case ResultsState.TO_VERIFY:
-                                toVerify++;
-                                break;
-                            case ResultsState.NOT_EXPLOITABLE:
-                                notExploitableMarked++;
-                                break;
-                            case ResultsState.PROPOSED_NOT_EXPLOITABLE:
-                                pneMarked++;
-                                break;
-                            case ResultsState.CONFIRMED:
-                            case ResultsState.URGENT:
-                                break;
-                            default:
+                            if (vuln.State != ResultsState.CONFIRMED.ToString() && vuln.State != ResultsState.URGENT.ToString())
                                 otherStates++;
-                                break;
                         }
                     }
                 }

--- a/Checkmarx.API.AST/Services/SASTResults.cs
+++ b/Checkmarx.API.AST/Services/SASTResults.cs
@@ -1040,8 +1040,8 @@ namespace Checkmarx.API.AST.Services.SASTResults
         public System.Collections.Generic.ICollection<ResultNode> Nodes { get; set; }
 
         [Newtonsoft.Json.JsonProperty("state", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public ResultsState State { get; set; }
+        //[Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public string State { get; set; }
 
         [Newtonsoft.Json.JsonProperty("changeDetails", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public ChangeDetails ChangeDetails { get; set; }

--- a/Checkmarx.API.AST/Services/SASTResultsPredicates.cs
+++ b/Checkmarx.API.AST/Services/SASTResultsPredicates.cs
@@ -377,7 +377,7 @@ namespace Checkmarx.API.AST.Services.SASTResultsPredicates
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 201)
+                        if (status_ == 200 || status_ == 201)
                         {
                             return;
                         }
@@ -1228,9 +1228,12 @@ namespace Checkmarx.API.AST.Services.SASTResultsPredicates
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public Checkmarx.API.AST.Services.SASTResults.ResultsSeverity Severity { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("state", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Include)]
+        [Newtonsoft.Json.JsonProperty("state", Required = Newtonsoft.Json.Required.AllowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public ResultsState State { get; set; }
+        public ResultsState? State { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("customStateId", Required = Newtonsoft.Json.Required.AllowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public long? CustomStateId { get; set; }
 
         /// <summary>
         /// comment that describe why the state has predicated

--- a/Checkmarx.API.AST/Utils/EnumUtils.cs
+++ b/Checkmarx.API.AST/Utils/EnumUtils.cs
@@ -1,6 +1,13 @@
-﻿using System;
+﻿using Checkmarx.API.AST.Models;
+using Checkmarx.API.AST.Models.SCA;
+using Checkmarx.API.AST.Services.KicsResults;
+using Checkmarx.API.AST.Services.SASTResults;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 
 namespace Checkmarx.API.AST.Utils
 {
@@ -26,6 +33,59 @@ namespace Checkmarx.API.AST.Utils
             }
 
             throw new InvalidOperationException($"'{description}' is not a valid {typeof(T).Name}.");
+        }
+
+        public static List<ResultState> GetStateEnumMemberList<T>() where T : Enum
+        {
+            if (typeof(T) == typeof(ResultsState))
+            {
+                return Enum.GetValues(typeof(ResultsState))
+                        .Cast<ResultsState>()
+                        .Select(state => new SASTResultState
+                        {
+                            Id = (int)state,
+                            Name = typeof(ResultsState)
+                                .GetField(state.ToString())
+                                ?.GetCustomAttribute<EnumMemberAttribute>()?.Value ?? state.ToString(),
+                            State = state
+                        })
+                        .OfType<ResultState>()
+                        .ToList();
+            }
+            else if (typeof(T) == typeof(ScaVulnerabilityStatus))
+            {
+                return Enum.GetValues(typeof(ScaVulnerabilityStatus))
+                        .Cast<ScaVulnerabilityStatus>()
+                        .Select(state => new SCAResultState
+                        {
+                            Id = (int)state,
+                            Name = typeof(ScaVulnerabilityStatus)
+                                .GetField(state.ToString())
+                                ?.GetCustomAttribute<EnumMemberAttribute>()?.Value ?? state.ToString(),
+                            State = state
+                        })
+                        .OfType<ResultState>()
+                        .ToList();
+            }
+            else if (typeof(T) == typeof(KicsStateEnum))
+            {
+                return Enum.GetValues(typeof(KicsStateEnum))
+                        .Cast<KicsStateEnum>()
+                        .Select(state => new KicsResultState
+                        {
+                            Id = (int)state,
+                            Name = typeof(KicsStateEnum)
+                                .GetField(state.ToString())
+                                ?.GetCustomAttribute<EnumMemberAttribute>()?.Value ?? state.ToString(),
+                            State = state
+                        })
+                        .OfType<ResultState>()
+                        .ToList();
+            }
+            else
+            {
+                throw new ArgumentException($"Unsupported enum type: {typeof(T).Name}. Supported types are ResultsState, ScaVulnerabilityStatus, and KicsStateEnum.");
+            }
         }
     }
 }


### PR DESCRIPTION
Change API result status to string due to custom status. 
Added properties for each engine states in ASTClient
Small tweaks to mark findings methods to allow the change of severity too